### PR TITLE
feat: implement multi-channel logging (Kafka, Elasticsearch, File, DB) with health checks & Laravel 12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-07-09
+
+This is a major release introducing multiple channel logging capabilities (Kafka, Elasticsearch, Database, File), asynchronous job dispatching with robust error fallback logging, and support for Laravel 12.x and PHP 8.2+.
+
+### Added
+- **Multiple Logging Channels**: Support for sending request/response logs to multiple channels simultaneously (configured via `FOOTPRINTS_CHANNELS`).
+- **Kafka Integration**: Native Kafka channel driver for streaming footprints to Apache Kafka brokers (requires `ext-rdkafka` PHP extension).
+- **Elasticsearch Integration**: Native Elasticsearch channel driver supporting indexing and push to data streams.
+- **File Logging Channel**: Dedicated file channel driver to persist request footprints locally, with validation to prevent disk exhaustion (`FileChannelValidator`).
+- **Service Reachability & Health Monitors**: Added robust TCP checks for Kafka brokers and HTTP checks for Elasticsearch nodes to ensure connectivity before logging.
+- **Fallback Logging**: Implemented a fallback mechanism in `ProcessFootprintJob` that automatically falls back to local file logging if all primary logging channels fail.
+- **Rich Request Metadata**: Expanded logged request details to include `request_headers`, `environment`, `user_agent`, `host_name`, `host_ip`, and `ip_address`.
+- **Dynamic Table Naming**: Configurable database table name using the `FOOTPRINTS_TABLE_NAME` environment variable.
+- **Migration Renaming on Publish**: Middleware/Service provider now renames migrations upon publishing (`php artisan vendor:publish`) to match the latest timestamp and avoid migration order clashes.
+- **Unit and Integration Tests**: Added a full test suite covering `CaptureFootprintsMiddleware`, `ProcessFootprintJob`, header redaction, and Service Provider registration.
+
+### Changed
+- **Modernized Middleware**: Replaced legacy `WriteFootprints` middleware with `CaptureFootprintsMiddleware` featuring cleaner payload construction and automatic `X-Request-ID` generation.
+- **Configuration Overhaul**: Renamed the config file from `src/config/config.php` to `src/config/footprints.php` and structured config keys for all channel drivers.
+- **Direct Query Builder Insertion**: Replaced Eloquent model logging with raw Query Builder inserts in `DatabaseChannel` to avoid model overhead and improve logging speed.
+- **Dependencies Upgrade**:
+  - Required PHP version bumped to `^8.2`.
+  - Added support for Illuminate components `^9.0|^10.0|^11.0|^12.0` (Laravel 9.x - 12.x).
+  - Configured `orchestra/testbench` up to `^10.0` and PHPUnit up to `^10.0` for testing compatibility.
+- **Improved Redaction Engine**: Upgraded sensitive data masking to recursively mask nested arrays, support hyphenated header/parameter matching, and handle multiple config-defined mask keys.
+
+### Removed
+- **Eloquent Model**: Deleted the `Footprint` Eloquent model and associated factory (`FootprintFactory`) in favor of direct Query Builder insertion.
+- **Legacy Files**: Cleaned up the old `WriteFootprints` middleware, config layout, and unused editor configuration files.

--- a/src/Channels/FileChannel.php
+++ b/src/Channels/FileChannel.php
@@ -2,10 +2,15 @@
 
 namespace TNM\Footprints\Channels;
 
+use Illuminate\Support\Facades\File;
+
 class FileChannel extends BaseChannel
 {
     public function log(array $footprint, array $config): void
     {
-        // disabled for now
+        $path = $config['path'] ?? storage_path('logs/footprints.log');
+        $logEntry = $this->safeJsonEncode($footprint) . PHP_EOL;
+
+        File::append($path, $logEntry);
     }
 }

--- a/src/Channels/KafkaChannel.php
+++ b/src/Channels/KafkaChannel.php
@@ -18,7 +18,7 @@ class KafkaChannel extends BaseChannel
     public function log(array $footprint, array $config): void
     {
         if (!extension_loaded('rdkafka') || !class_exists(\RdKafka\Producer::class)) {
-            throw new Exception("RdKafka extension not installed or enabled.");
+            throw new Exception("RdKafka extension not installed nor enabled.");
         }
 
         $this->ensureConnectivity($config['brokers']);

--- a/src/Helpers/IdKeyGenerator.php
+++ b/src/Helpers/IdKeyGenerator.php
@@ -2,6 +2,8 @@
 
 namespace TNM\Footprints\Helpers;
 
+use InvalidArgumentException;
+
 class IdKeyGenerator
 {
     /**
@@ -22,7 +24,7 @@ class IdKeyGenerator
             // Use field from footprint
             $id = $footprint[$idConfig] ?? null;
             if ($id === null) {
-                throw new \InvalidArgumentException("Field '{$idConfig}' not found in footprint data");
+                throw new InvalidArgumentException("Field '{$idConfig}' not found in footprint data");
             }
             return (string)$id;
         }
@@ -30,14 +32,14 @@ class IdKeyGenerator
         if (is_callable($idConfig)) {
             $id = call_user_func($idConfig, $footprint);
             if (!is_string($id) && !is_numeric($id)) {
-                throw new \InvalidArgumentException("ID generation function must return a string or numeric value");
+                throw new InvalidArgumentException("ID generation function must return a string or numeric value");
             }
             $id = (string)$id;
             self::validateLength($id, 'document ID');
             return $id;
         }
 
-        throw new \InvalidArgumentException("Document ID config must be a string (field name) or callable");
+        throw new InvalidArgumentException("Document ID config must be a string (field name) or callable");
     }
 
     /**
@@ -67,14 +69,14 @@ class IdKeyGenerator
                 return null;
             }
             if (!is_string($key) && !is_numeric($key)) {
-                throw new \InvalidArgumentException("Key generation function must return a string, numeric value, or null");
+                throw new InvalidArgumentException("Key generation function must return a string, numeric value, or null");
             }
             $key = (string)$key;
             self::validateLength($key, 'message key');
             return $key;
         }
 
-        throw new \InvalidArgumentException("Message key config must be null, a string (field name), or callable");
+        throw new InvalidArgumentException("Message key config must be null, a string (field name), or callable");
     }
 
     /**
@@ -83,12 +85,12 @@ class IdKeyGenerator
      * @param string $value
      * @param string $type
      * @return void
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected static function validateLength(string $value, string $type): void
     {
         if (strlen($value) > self::MAX_LENGTH) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Generated {$type} exceeds maximum length of " . self::MAX_LENGTH . " characters"
             );
         }

--- a/src/Jobs/ProcessFootprintJob.php
+++ b/src/Jobs/ProcessFootprintJob.php
@@ -13,6 +13,7 @@ use Throwable;
 use TNM\Footprints\Channels\ChannelInterface;
 use TNM\Footprints\Channels\DatabaseChannel;
 use TNM\Footprints\Channels\ElasticsearchChannel;
+use TNM\Footprints\Channels\FileChannel;
 use TNM\Footprints\Channels\KafkaChannel;
 
 class ProcessFootprintJob implements ShouldQueue
@@ -31,6 +32,12 @@ class ProcessFootprintJob implements ShouldQueue
     private function fallback(string $reason): void
     {
         Log::warning("[Footprint Package] Failed to log footprint: $reason");
+
+        $fileConfig = config('footprints.drivers.file', []);
+        $path = $fileConfig['path'] ?? storage_path('logs/footprints.log');
+        $entry = json_encode(['error' => $reason, 'footprint' => $this->footprint]) . PHP_EOL;
+
+        file_put_contents($path, $entry, FILE_APPEND);
     }
 
     public function handle(): void
@@ -65,6 +72,7 @@ class ProcessFootprintJob implements ShouldQueue
     {
         return match (strtolower($channel)) {
             'database' => new DatabaseChannel(),
+            'file' => new FileChannel(),
             'kafka' => new KafkaChannel(),
             'elasticsearch' => new ElasticsearchChannel(),
             default => throw new Exception("Unknown channel: $channel"),

--- a/tests/Unit/ProcessFootprintJobTest.php
+++ b/tests/Unit/ProcessFootprintJobTest.php
@@ -2,6 +2,8 @@
 
 namespace TNM\Footprints\Tests\Unit;
 
+use Exception;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
@@ -10,11 +12,22 @@ use TNM\Footprints\Tests\TestCase;
 
 class ProcessFootprintJobTest extends TestCase
 {
-    protected $footprintData;
+    protected array $footprintData;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        $logDirectory = storage_path('logs');
+        if (!File::exists($logDirectory)) {
+            File::makeDirectory($logDirectory, 0755, true);
+        }
+
+        $this->app['config']->set('logging.channels.footprints', [
+            'driver' => 'single',
+            'path' => storage_path('logs/footprints.log'),
+            'level' => 'debug',
+        ]);
 
         $this->footprintData = [
             'request_id' => 'uuid-1234',
@@ -49,12 +62,15 @@ class ProcessFootprintJobTest extends TestCase
         ]);
     }
 
+    /**
+     * @throws FileNotFoundException
+     */
     public function test_it_logs_to_file()
     {
         $this->app['config']->set('footprints.channels', ['file']);
-        
+
         $logPath = storage_path('logs/footprints.log');
-        
+
         if (File::exists($logPath)) {
             File::delete($logPath);
         }
@@ -68,10 +84,13 @@ class ProcessFootprintJobTest extends TestCase
         $this->assertStringContainsString('api\/test', $content);
     }
 
+    /**
+     * @throws FileNotFoundException
+     */
     public function test_it_handles_multiple_channels()
     {
         $this->app['config']->set('footprints.channels', ['database', 'file']);
-        
+
         $logPath = storage_path('logs/footprints.log');
         if (File::exists($logPath)) {
             File::delete($logPath);
@@ -92,7 +111,7 @@ class ProcessFootprintJobTest extends TestCase
     public function test_it_handles_string_channel_config()
     {
         $this->app['config']->set('footprints.channels', 'database,file');
-        
+
         $logPath = storage_path('logs/footprints.log');
         if (File::exists($logPath)) {
             File::delete($logPath);
@@ -108,37 +127,38 @@ class ProcessFootprintJobTest extends TestCase
     public function test_safe_json_encode_handles_binary_data()
     {
         $this->app['config']->set('footprints.channels', ['database']);
-        
-        // Create a string with invalid UTF-8 sequence
+
         $invalidUtf8 = "\xB1\x31";
-        
+
         $data = $this->footprintData;
         $data['request_body'] = ['bad_string' => $invalidUtf8];
 
-        $job = new ProcessFootprintJob($data);
-        $job->handle();
+        (new ProcessFootprintJob($data))->handle();
 
         $this->assertDatabaseHas('footprints', [
             'request_id' => 'uuid-1234',
         ]);
-        
+
         $record = DB::table('footprints')->where('request_id', 'uuid-1234')->first();
-        // Since we use JSON_INVALID_UTF8_SUBSTITUTE, it shouldn't crash and should substitute
+
         $this->assertStringContainsString('bad_string', $record->request_body);
     }
-    
+
+    /**
+     * @throws FileNotFoundException
+     */
     public function test_failed_job_triggers_fallback_log()
     {
-        Log::shouldReceive('warning')->once();
-        
-        $job = new ProcessFootprintJob($this->footprintData);
-        $exception = new \Exception("Something went wrong");
-        
-        $job->failed($exception);
-        
+        Log::partialMock()->shouldReceive('warning')->once();
+
+        (new ProcessFootprintJob($this->footprintData))->failed(new Exception("Something went wrong"));
+
         $logPath = storage_path('logs/footprints.log');
+
+        $this->assertFileExists($logPath);
+
         $content = File::get($logPath);
-        
+
         $this->assertStringContainsString('Something went wrong', $content);
         $this->assertStringContainsString('uuid-1234', $content);
     }


### PR DESCRIPTION
## Summary
This Pull Request updates the `footprints` request/response logging package to version `2.0.0`. 
It introduces a multichannel logging system, native Kafka and Elasticsearch channels, pre-flight service health monitoring, and
upgrades core dependencies to support PHP 8.2+ and Laravel 9.x through 12.x.

## Key Changes

### 1. Multi-Channel Logging Architecture
- Replaced the single-channel logging structure with a multichannel driver system. You can now log footprints to multiple channels simultaneously using comma-separated values in the `FOOTPRINTS_CHANNELS` env variable.
- Supported drivers: `database`, `file`, `kafka`, and `elasticsearch`.

### 2. New Channel Drivers
- **Kafka**: Native channel driver using `rdkafka` to stream logs directly to Apache Kafka brokers.
- **Elasticsearch**: Support for pushing to Elasticsearch logs index or pushing directly to a data stream.
- **File**: Direct file logging channel with validations to check available disk space.

### 3. Service Reachability & Fallback Logging
- Added pre-flight connectivity checks for services: `TCPCheck` for Kafka brokers and `HTTPCheck` for Elasticsearch nodes.
- Implemented error handling in ProcessFootprintJob.php so that one channel's failure does not block other channels.
- Added a fallback logging channel that redirects logs to a local file if all target logging channels fail or are unreachable.

### 4. Middleware & Payload Refactoring
- Deprecated `WriteFootprints` middleware and introduced CaptureFootprintsMiddleware.php.
- Replaced Eloquent model logs with raw Query Builder inserts in DatabaseChannel.php to eliminate ORM overhead.
- Captured additional request and environment metadata: `request_headers`, `environment`, `user_agent`, `host_name`, `host_ip`, and `ip_address`.
- Enhanced recursive sensitive data masking supporting custom parameters and headers.

### 5. Config Overhaul
- Renamed the configuration file from `config.php` to footprints.php, exposing dedicated environment variables and drivers sections.

### 6. Dependency & Ecosystem Support
- Required PHP `^8.2`.
- Added support for Laravel/Illuminate `^9.0|^10.0|^11.0|^12.0`.
- Integrated Orchestra Testbench `^10.0` and PHPUnit `^10.0` with a fully passing test suite.

## Verification & Testing
All unit and integration tests are passing successfully:
```bash
composer test
```
